### PR TITLE
Implement WaiterQueue

### DIFF
--- a/lua/autorun/server/sv_waiter.lua
+++ b/lua/autorun/server/sv_waiter.lua
@@ -13,6 +13,7 @@ local maxAttempts = 10
 local minBreakAfterAttending = 1
 
 local function generatePatron( waitingFor, onSuccess, onTimeout )
+    print( "[CFC Waiter] Generating new Patron!" )
     local patron = {}
     patron["onSuccess"] = onSuccess
     patron["onTimeout"] = onTimeout
@@ -22,6 +23,7 @@ local function generatePatron( waitingFor, onSuccess, onTimeout )
     patronQueue[patronCount] = patron
 
     patronCount = patronCount + 1
+    print( "[CFC Waiter] New Patron Count: " .. tostring(patronCount) )
 end
 
 local function removePatron( patronID )
@@ -29,24 +31,30 @@ local function removePatron( patronID )
 end
 
 function Waiter.waitFor( waitingFor, onSuccess, onTimeout )
+    print( "[CFC Waiter] Registering new Patron!" )
     generatePatron( waitingFor, onSuccess, onTimeout )
 end
 
 local function attendPatron( patronID, patron )
+    print( "[CFC Waiter] Attending to patron ID: " .. tostring( patronID ) )
     if patron.attempts >= maxAttempts then
+        print( "[CFC Waiter] Patron ID " .. tostring( patronID ) .. " has reached max attempts! Running onTimeout and removing.." )
         patron.onTimeout()
         return removePatron( patronID )
     end
 
     if patron.waitingFor() == true then
+        print( "[CFC Waiter] Patron ID " .. tostring( patronID ) .. " was successful! Running onSuccess and removing.. " )
         patron.onSuccess()
         return removePatron( patronID )
     end
 
+    print( "[CFC Waiter] Patron ID: " .. tostring( patronID ) .. " failed to return true. Incrementing attempts.. " )
     patron.attempts = patron.attempts + 1
 end
 
 local function attendPatrons()
+    print( "[CFC Waiter] Attending to patrons.. " )
     local startTime = SysTime()
 
     for patronID, patron in pairs(patronQueue) do
@@ -58,13 +66,19 @@ local function attendPatrons()
 
     Waiter.lastLoopDuration = elapsedTime
 
+    print( "[CFC Waiter] Finished attending to patrons. Elapsed time: " .. tostring(elapstedTime) )
+
     local delayTime = math.max( 0, minBreakAfterAttending - elapsedTime )
+
+    print( "[CFC Waiter] Next delay time: " .. tostring(delayTime) )
 
     timer.Simple( delayTime, attendPatrons )
 end
 
 local function getPatronsFromQueue()
+    print( "[CFC Waiter] Retrieving patrons from WaiterQueue.." )
     for _, patron in pairs(WaiterQueue) do
+        print( "[CFC Waiter] Found patron in WaiterQueue! Importing.." )
         generatePatron( patron["waitingFor"], patron["onSuccess"], patron["onTimeout"] )
     end
 end

--- a/lua/autorun/server/sv_waiter.lua
+++ b/lua/autorun/server/sv_waiter.lua
@@ -1,4 +1,5 @@
 Waiter = {}
+WaiterQueue = WaiterQueue or {}
 
 -- Last execution time of attendPatrons()
 Waiter.lastLoopDuration = 0
@@ -11,8 +12,7 @@ local maxAttempts = 10
 -- Minimum delay between executions of attendPatrons()
 local minBreakAfterAttending = 1
 
-function Waiter.waitFor( waitingFor, onSuccess, onTimeout )
-
+local function generatePatron( waitingFor, onSuccess, onTimeout )
     local patron = {}
     patron["onSuccess"] = onSuccess
     patron["onTimeout"] = onTimeout
@@ -26,6 +26,10 @@ end
 
 local function removePatron( patronID )
     patronQueue[patronID] = nil
+end
+
+function Waiter.waitFor( waitingFor, onSuccess, onTimeout )
+    generatePatron( waitingFor, onSuccess, onTimeout )
 end
 
 local function attendPatron( patronID, patron )
@@ -59,4 +63,11 @@ local function attendPatrons()
     timer.Simple( delayTime, attendPatrons )
 end
 
+local function getPatronsFromQueue()
+    for _, patron in pairs(WaiterQueue) do
+        generatePatron( patron["waitingFor"], patron["onSuccess"], patron["onTimeout"] )
+    end
+end
+
+getPatronsFromQueue()
 attendPatrons()


### PR DESCRIPTION
Allows other addons to insert their patrons into a global WaiterQueue so Waiter can pick them up when it loads.

This helps ensure that other addons can still use Waiter even if they load before Waiter.